### PR TITLE
Added support for long texture names

### DIFF
--- a/Source/Core/Config/ThingTypeInfo.cs
+++ b/Source/Core/Config/ThingTypeInfo.cs
@@ -159,10 +159,7 @@ namespace CodeImp.DoomBuilder.Config
 			if(this.radius < 4f) this.radius = 8f;
 			
 			// Make long name for sprite lookup
-			if(this.sprite.Length <= 8)
-				this.spritelongname = Lump.MakeLongName(this.sprite);
-			else
-				this.spritelongname = long.MaxValue;
+			this.spritelongname = Lump.MakeLongName(this.sprite);
 			
 			// We have no destructor
 			GC.SuppressFinalize(this);
@@ -199,10 +196,7 @@ namespace CodeImp.DoomBuilder.Config
 			if(this.radius < 4f) this.radius = 8f;
 			
 			// Make long name for sprite lookup
-			if(this.sprite.Length <= 8)
-				this.spritelongname = Lump.MakeLongName(this.sprite);
-			else
-				this.spritelongname = long.MaxValue;
+			this.spritelongname = Lump.MakeLongName(this.sprite);
 
 			// We have no destructor
 			GC.SuppressFinalize(this);
@@ -269,10 +263,7 @@ namespace CodeImp.DoomBuilder.Config
 			string suitablesprite = actor.FindSuitableSprite();
 			if(!string.IsNullOrEmpty(suitablesprite)) sprite = suitablesprite;
 			
-			if(this.sprite.Length <= 8)
-				this.spritelongname = Lump.MakeLongName(this.sprite);
-			else
-				this.spritelongname = long.MaxValue;
+			this.spritelongname = Lump.MakeLongName(this.sprite);
 			
 			// Set sprite scale
 			if(actor.HasPropertyWithValue("scale"))

--- a/Source/Core/Controls/LinedefInfoPanel.Designer.cs
+++ b/Source/Core/Controls/LinedefInfoPanel.Designer.cs
@@ -507,9 +507,11 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // frontlowname
             // 
+            this.frontlowname.AutoSize = true;
             this.frontlowname.BackColor = System.Drawing.SystemColors.Control;
             this.frontlowname.Location = new System.Drawing.Point(212, 90);
             this.frontlowname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.frontlowname.MinimumSize = new System.Drawing.Size(102, 26);
             this.frontlowname.Name = "frontlowname";
             this.frontlowname.Size = new System.Drawing.Size(102, 26);
             this.frontlowname.TabIndex = 5;
@@ -530,9 +532,11 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // fronthighname
             // 
+            this.fronthighname.AutoSize = true;
             this.fronthighname.BackColor = System.Drawing.SystemColors.Control;
             this.fronthighname.Location = new System.Drawing.Point(8, 90);
             this.fronthighname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.fronthighname.MinimumSize = new System.Drawing.Size(102, 26);
             this.fronthighname.Name = "fronthighname";
             this.fronthighname.Size = new System.Drawing.Size(102, 26);
             this.fronthighname.TabIndex = 1;
@@ -553,9 +557,11 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // frontmidname
             // 
+            this.frontmidname.AutoSize = true;
             this.frontmidname.BackColor = System.Drawing.SystemColors.Control;
             this.frontmidname.Location = new System.Drawing.Point(110, 90);
             this.frontmidname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.frontmidname.MinimumSize = new System.Drawing.Size(102, 26);
             this.frontmidname.Name = "frontmidname";
             this.frontmidname.Size = new System.Drawing.Size(102, 26);
             this.frontmidname.TabIndex = 3;
@@ -604,9 +610,11 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // backlowname
             // 
+            this.backlowname.AutoSize = true;
             this.backlowname.BackColor = System.Drawing.SystemColors.Control;
             this.backlowname.Location = new System.Drawing.Point(212, 90);
             this.backlowname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.backlowname.MinimumSize = new System.Drawing.Size(102, 26);
             this.backlowname.Name = "backlowname";
             this.backlowname.Size = new System.Drawing.Size(102, 26);
             this.backlowname.TabIndex = 5;
@@ -616,9 +624,11 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // backmidname
             // 
+            this.backmidname.AutoSize = true;
             this.backmidname.BackColor = System.Drawing.SystemColors.Control;
             this.backmidname.Location = new System.Drawing.Point(110, 90);
             this.backmidname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.backmidname.MinimumSize = new System.Drawing.Size(102, 26);
             this.backmidname.Name = "backmidname";
             this.backmidname.Size = new System.Drawing.Size(102, 26);
             this.backmidname.TabIndex = 3;
@@ -639,9 +649,11 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // backhighname
             // 
+            this.backhighname.AutoSize = true;
             this.backhighname.BackColor = System.Drawing.SystemColors.Control;
             this.backhighname.Location = new System.Drawing.Point(8, 90);
             this.backhighname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.backhighname.MinimumSize = new System.Drawing.Size(102, 26);
             this.backhighname.Name = "backhighname";
             this.backhighname.Size = new System.Drawing.Size(102, 26);
             this.backhighname.TabIndex = 1;

--- a/Source/Core/Controls/SectorInfoPanel.Designer.cs
+++ b/Source/Core/Controls/SectorInfoPanel.Designer.cs
@@ -201,8 +201,10 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // ceilingname
             // 
+            this.ceilingname.AutoSize = true;
             this.ceilingname.Location = new System.Drawing.Point(405, 80);
             this.ceilingname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.ceilingname.MinimumSize = new System.Drawing.Size(105, 20);
             this.ceilingname.Name = "ceilingname";
             this.ceilingname.Size = new System.Drawing.Size(105, 20);
             this.ceilingname.TabIndex = 1;
@@ -233,8 +235,10 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // floorname
             // 
+            this.floorname.AutoSize = true;
             this.floorname.Location = new System.Drawing.Point(286, 80);
             this.floorname.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.floorname.MinimumSize = new System.Drawing.Size(105, 20);
             this.floorname.Name = "floorname";
             this.floorname.Size = new System.Drawing.Size(105, 20);
             this.floorname.TabIndex = 1;

--- a/Source/Core/Controls/ThingInfoPanel.Designer.cs
+++ b/Source/Core/Controls/ThingInfoPanel.Designer.cs
@@ -317,8 +317,10 @@ namespace CodeImp.DoomBuilder.Controls
             // 
             // spritename
             // 
+            this.spritename.AutoSize = true;
             this.spritename.Location = new System.Drawing.Point(14, 85);
             this.spritename.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.spritename.MinimumSize = new System.Drawing.Size(105, 16);
             this.spritename.Name = "spritename";
             this.spritename.Size = new System.Drawing.Size(105, 16);
             this.spritename.TabIndex = 1;

--- a/Source/Core/Controls/ThingInfoPanel.cs
+++ b/Source/Core/Controls/ThingInfoPanel.cs
@@ -152,7 +152,7 @@ namespace CodeImp.DoomBuilder.Controls
 				spritename.Text = "";
 				General.DisplayZoomedImage(spritetex, General.Map.Data.GetSpriteImage(ti.Sprite).GetBitmap());
 			}
-			else if((ti.Sprite.Length <= 8) && (ti.Sprite.Length > 0))
+			else if(ti.Sprite.Length > 0)
 			{
 				spritename.Text = ti.Sprite;
 				General.DisplayZoomedImage(spritetex, General.Map.Data.GetSpriteImage(ti.Sprite).GetPreview());

--- a/Source/Core/Data/DataManager.cs
+++ b/Source/Core/Data/DataManager.cs
@@ -1184,7 +1184,7 @@ namespace CodeImp.DoomBuilder.Data
 			foreach(ThingTypeInfo ti in General.Map.Data.ThingTypes)
 			{
 				// Valid sprite name?
-				if((ti.Sprite.Length > 0) && (ti.Sprite.Length <= 8))
+				if(ti.Sprite.Length > 0)
 				{
 					ImageData image = null;
 					

--- a/Source/Core/Data/PK3StructuredReader.cs
+++ b/Source/Core/Data/PK3StructuredReader.cs
@@ -442,15 +442,16 @@ namespace CodeImp.DoomBuilder.Data
 			List<ImageData> images = new List<ImageData>();
 			string[] files;
 			string name;
-			
-			// Go for all files
-			files = GetAllFiles(path, includesubdirs);
+            int maxTextureNameLength = General.Map.Config.MaxTextureNamelength;
+
+            // Go for all files
+            files = GetAllFiles(path, includesubdirs);
 			foreach(string f in files)
 			{
 				// Make the texture name from filename without extension
 				name = Path.GetFileNameWithoutExtension(f).ToUpperInvariant();
-				if(name.Length > 8) name = name.Substring(0, 8);
-				if(name.Length > 0)
+                if ((maxTextureNameLength > 0) && (name.Length > maxTextureNameLength)) name = name.Substring(0, maxTextureNameLength);
+                if (name.Length > 0)
 				{
 					// Add image to list
 					images.Add(CreateImage(name, f, imagetype));
@@ -474,6 +475,7 @@ namespace CodeImp.DoomBuilder.Data
             List<ImageData> images = new List<ImageData>();
             string[] files;
             string name;
+            int maxTextureNameLength = General.Map.Config.MaxTextureNamelength;
             
             // Go for all files
             files = GetAllFiles(path, true);
@@ -481,7 +483,7 @@ namespace CodeImp.DoomBuilder.Data
             {
                 // Make the texture name from filename without extension
                 name = Path.GetFileNameWithoutExtension(f).ToUpperInvariant();
-                if (name.Length > 8) name = name.Substring(0, 8);
+                if ((maxTextureNameLength > 0) && (name.Length > maxTextureNameLength)) name = name.Substring(0, maxTextureNameLength);
                 if (name.Length > 0)
                 {
                     // Add image to list

--- a/Source/Core/General/MapManager.cs
+++ b/Source/Core/General/MapManager.cs
@@ -85,9 +85,12 @@ namespace CodeImp.DoomBuilder
 		private List<CompilerError> errors;
 		private VisualCamera visualcamera;
         private bool issaving;
-		
-		// Disposing
-		private bool isdisposed = false;
+
+        // bmsq - GH-6: Long name support
+        private Dictionary<string, long> longnameindex;
+
+        // Disposing
+        private bool isdisposed = false;
 
 		#endregion
 
@@ -119,6 +122,9 @@ namespace CodeImp.DoomBuilder
 		public VisualCamera VisualCamera { get { return visualcamera; } set { visualcamera = value; } }
 		public bool IsScriptsWindowOpen { get { return (scriptwindow != null) && !scriptwindow.IsDisposed; } }
         public bool IsSaving { get { return issaving; } }
+
+        // bmsq - GH-6: Long name support
+        internal Dictionary<string, long> LongNameIndex { get { return longnameindex; } }
 
         // ano - UI stuff on a timer should check this before interacting with the map
         // in case the map is being edited in another thread
@@ -249,7 +255,10 @@ namespace CodeImp.DoomBuilder
 			this.changed = false;
 			this.options = options;
 
-			Logger.WriteLogLine("Creating new map '" + options.CurrentName + "' with configuration '" + options.ConfigFile + "'");
+            // bmsq - GH-6: longnames indexed by names longer than 8
+            longnameindex = new Dictionary<string, long>();
+
+            Logger.WriteLogLine("Creating new map '" + options.CurrentName + "' with configuration '" + options.ConfigFile + "'");
 
 			// Initiate graphics
 			Logger.WriteLogLine("Initializing graphics device...");
@@ -336,8 +345,11 @@ namespace CodeImp.DoomBuilder
 			this.filepathname = filepathname;
 			this.changed = false;
 			this.options = options;
-			
-			Logger.WriteLogLine("InitializeOpenMap: Opening map '" + options.CurrentName + "' with configuration '" + options.ConfigFile + "'");
+
+            // bmsq - GH-6: longnames indexed by names longer than 8
+            longnameindex = new Dictionary<string, long>();
+
+            Logger.WriteLogLine("InitializeOpenMap: Opening map '" + options.CurrentName + "' with configuration '" + options.ConfigFile + "'");
 
 			// Initiate graphics
 			Logger.WriteLogLine("InitializeOpenMap: Initializing graphics device...");

--- a/Source/Core/IO/Lump.cs
+++ b/Source/Core/IO/Lump.cs
@@ -54,8 +54,8 @@ namespace CodeImp.DoomBuilder.IO
 		// Disposing
 		private bool isdisposed = false;
 
-        // bmsq - string to longname index, used when name.length > 8
-        private static Dictionary<string, long> longnameindex = new Dictionary<string, long>();
+		// bmsq - string to longname index, used when name.length > 8
+		private static Dictionary<string, long> longnameindex = new Dictionary<string, long>();
 
 		#endregion
 
@@ -84,11 +84,11 @@ namespace CodeImp.DoomBuilder.IO
 			this.offset = offset;
 			this.length = length;
 
-            // Make name
-            MakeNames(fixedname);
+			// Make name
+			MakeNames(fixedname);
 
-            // We have no destructor
-            GC.SuppressFinalize(this);
+			// We have no destructor
+			GC.SuppressFinalize(this);
 		}
 
 		// Disposer
@@ -106,106 +106,106 @@ namespace CodeImp.DoomBuilder.IO
 			}
 		}
 
-        #endregion
+		#endregion
 
-        #region ================== Methods
+		#region ================== Methods
 
-        // This returns the long value for a 8 byte texture name
-        private void MakeNames(byte[] in_fixed)
-        {
-            /*
-            this.name = MakeNormalName(in_fixed, WAD.ENCODING).ToUpperInvariant();
+		// This returns the long value for a 8 byte texture name
+		private void MakeNames(byte[] in_fixed)
+		{
+			/*
+			this.name = MakeNormalName(in_fixed, WAD.ENCODING).ToUpperInvariant();
 			this.fixedname = MakeFixedName(name, WAD.ENCODING);
-            this.longname = MakeLongName(name);
-            */
+			this.longname = MakeLongName(name);
+			*/
 
-            int length;
-            
-            // Figure out the length of the lump name
-            {
-                int orig_length = in_fixed.Length;
-                int l = 0;
-                int r = orig_length;
-                while (r - l > 1)
-                {
-                    int m = (r + l) / 2;
+			int length;
+			
+			// Figure out the length of the lump name
+			{
+				int orig_length = in_fixed.Length;
+				int l = 0;
+				int r = orig_length;
+				while (r - l > 1)
+				{
+					int m = (r + l) / 2;
 
-                    if (in_fixed[m] == 0)
-                    {
-                        r = m;
-                    }
-                    else
-                    {
-                        l = m;
-                    }
-                }
-                length = l + 1;
-            }
+					if (in_fixed[m] == 0)
+					{
+						r = m;
+					}
+					else
+					{
+						l = m;
+					}
+				}
+				length = l + 1;
+			}
 
-            // Make normal name
-            name = WAD.ENCODING.GetString(in_fixed, 0, length).Trim().ToUpperInvariant();
-
-
-            //makefixedname
-            {
-                int bytes = length;
-                if (bytes < 8) bytes = 8;
-
-                // Make 8 bytes, all zeros
-                fixedname = new byte[bytes];
-
-                // Write the name in bytes
-                WAD.ENCODING.GetBytes(name, 0, length, fixedname, 0);
-            }
-
-            //makelongname
-            unsafe
-            {
-                long value = 0;
-                uint bytes = (uint)length;
-
-                if (bytes > 8) bytes = 8;
-
-                fixed (void* bp = fixedname)
-                {
-                    General.CopyMemory(&value, bp, bytes);
-                }
-
-                longname = value;
-            }
+			// Make normal name
+			name = WAD.ENCODING.GetString(in_fixed, 0, length).Trim().ToUpperInvariant();
 
 
-        } // makenames
+			//makefixedname
+			{
+				int bytes = length;
+				if (bytes < 8) bytes = 8;
 
-        // This returns the long value for a 8 byte texture name
-        public static unsafe long MakeLongName(string name)
+				// Make 8 bytes, all zeros
+				fixedname = new byte[bytes];
+
+				// Write the name in bytes
+				WAD.ENCODING.GetBytes(name, 0, length, fixedname, 0);
+			}
+
+			//makelongname
+			unsafe
+			{
+				long value = 0;
+				uint bytes = (uint)length;
+
+				if (bytes > 8) bytes = 8;
+
+				fixed (void* bp = fixedname)
+				{
+					General.CopyMemory(&value, bp, bytes);
+				}
+
+				longname = value;
+			}
+
+
+		} // makenames
+
+		// This returns the long value for a 8 byte texture name
+		public static unsafe long MakeLongName(string name)
 		{
 			long value = 0;
-            string normalizedName = name.Trim().ToUpper();
+			string normalizedName = name.Trim().ToUpper();
 
-            byte[] namebytes = Encoding.ASCII.GetBytes(normalizedName);
+			byte[] namebytes = Encoding.ASCII.GetBytes(normalizedName);
 			uint bytes = (uint)namebytes.Length;
 
-            // bmsq - handle long file names
-            if ((bytes > 8) || ((bytes == 8) && (namebytes[0] > 0x7F)))
-            {
-                if (!longnameindex.TryGetValue(normalizedName, out value))
-                {
-                    value = longnameindex.Count;
-                    value |= unchecked((long)0x8000000000000000);
+			// bmsq - handle long file names
+			if ((bytes > 8) || ((bytes == 8) && (namebytes[0] > 0x7F)))
+			{
+				if (!longnameindex.TryGetValue(normalizedName, out value))
+				{
+					value = longnameindex.Count;
+					value |= unchecked((long)0x8000000000000000);
 
-                    longnameindex.Add(normalizedName, value);
-                }
-            }
-            else
-            {
-                fixed (void* bp = namebytes)
-                {
-                    General.CopyMemory(&value, bp, bytes);
-                }
-            }
+					longnameindex.Add(normalizedName, value);
+				}
+			}
+			else
+			{
+				fixed (void* bp = namebytes)
+				{
+					General.CopyMemory(&value, bp, bytes);
+				}
+			}
 
-            return value;
+			return value;
 		}
 		
 		// This makes the normal name from fixed name

--- a/Source/Core/IO/Lump.cs
+++ b/Source/Core/IO/Lump.cs
@@ -161,6 +161,7 @@ namespace CodeImp.DoomBuilder.IO
 				long value = 0;
 				uint bytes = (uint)length;
 
+                // bmsq - bytes > 8 will never happen here as this code is only ever used during WAD loading
 				if (bytes > 8) bytes = 8;
 
 				fixed (void* bp = fixedname)

--- a/Source/Core/IO/Lump.cs
+++ b/Source/Core/IO/Lump.cs
@@ -54,9 +54,6 @@ namespace CodeImp.DoomBuilder.IO
 		// Disposing
 		private bool isdisposed = false;
 
-		// bmsq - string to longname index, used when name.length > 8
-		private static Dictionary<string, long> longnameindex = new Dictionary<string, long>();
-
 		#endregion
 
 		#region ================== Properties
@@ -186,22 +183,22 @@ namespace CodeImp.DoomBuilder.IO
 			byte[] namebytes = Encoding.ASCII.GetBytes(normalizedName);
 			uint bytes = (uint)namebytes.Length;
 
-			// bmsq - handle long file names
-			if ((bytes > 8) || ((bytes == 8) && (namebytes[0] > 0x7F)))
+            // bmsq - GH-6: handle long file names 
+            if ((bytes > 8) || ((bytes == 8) && (namebytes[0] > 0x7F)))
 			{
-				if (!longnameindex.TryGetValue(normalizedName, out value))
+				if (!General.Map.LongNameIndex.TryGetValue(normalizedName, out value))
 				{
-					value = longnameindex.Count;
+					value = General.Map.LongNameIndex.Count;
 					value |= unchecked((long)0x8000000000000000);
 
-					longnameindex.Add(normalizedName, value);
+                    General.Map.LongNameIndex.Add(normalizedName, value);
 				}
 			}
 			else
 			{
 				fixed (void* bp = namebytes)
 				{
-					General.CopyMemory(&value, bp, bytes);
+                    General.CopyMemory(&value, bp, bytes);
 				}
 			}
 

--- a/Source/Core/IO/Lump.cs
+++ b/Source/Core/IO/Lump.cs
@@ -185,7 +185,22 @@ namespace CodeImp.DoomBuilder.IO
 			uint bytes = (uint)namebytes.Length;
 
             // bmsq - GH-6: handle long file names 
-            if ((bytes > 8) || ((bytes == 8) && (namebytes[0] > 0x7F)))
+            if ( (bytes < 8) || ((bytes == 8) && (namebytes[0] <= 0x7F)) || (General.Map == null))
+            {
+                /* 
+                a fallback for when General.Map is not available, this isn't a problem as
+                long names are only used for rendering and rendering isn't initialized until
+                a map is created or loaded.  When a map is created all configurations and 
+                resources are reloaded anyway.
+                 */
+                if (bytes > 8) bytes = 8;
+
+                fixed (void* bp = namebytes)
+                {
+                    General.CopyMemory(&value, bp, bytes);
+                }
+            }
+            else 
 			{
 				if (!General.Map.LongNameIndex.TryGetValue(normalizedName, out value))
 				{
@@ -195,14 +210,6 @@ namespace CodeImp.DoomBuilder.IO
                     General.Map.LongNameIndex.Add(normalizedName, value);
 				}
 			}
-			else
-			{
-				fixed (void* bp = namebytes)
-				{
-                    General.CopyMemory(&value, bp, bytes);
-				}
-			}
-
 			return value;
 		}
 		

--- a/Source/Core/Windows/ThingEditForm.cs
+++ b/Source/Core/Windows/ThingEditForm.cs
@@ -250,7 +250,7 @@ namespace CodeImp.DoomBuilder.Windows
 				{
 					General.DisplayZoomedImage(spritetex, General.Map.Data.GetSpriteImage(thinginfo.Sprite).GetBitmap());
 				}
-				else if((thinginfo.Sprite.Length <= 8) && (thinginfo.Sprite.Length > 0))
+				else if(thinginfo.Sprite.Length > 0)
 				{
 					General.DisplayZoomedImage(spritetex, General.Map.Data.GetSpriteImage(thinginfo.Sprite).GetPreview());
 				}

--- a/Source/Plugins/BuilderModes/FindReplace/FindAnyTextureFlat.cs
+++ b/Source/Plugins/BuilderModes/FindReplace/FindAnyTextureFlat.cs
@@ -97,7 +97,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			{
 				// If it cannot be interpreted, set replacewith to null (not replacing at all)
 				if(replacewith.Length < 0) replacewith = null;
-				if(replacewith.Length > 8) replacewith = null;
+				if((General.Map.Config.MaxTextureNamelength > 0) && (replacewith.Length > General.Map.Config.MaxTextureNamelength)) replacewith = null;
 				if(replacewith == null)
 				{
 					MessageBox.Show("Invalid replace value for this search type!", "Find and Replace", MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/Source/Plugins/BuilderModes/FindReplace/FindSectorFlat.cs
+++ b/Source/Plugins/BuilderModes/FindReplace/FindSectorFlat.cs
@@ -91,7 +91,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			{
 				// If it cannot be interpreted, set replacewith to null (not replacing at all)
 				if(replacewith.Length < 0) replacewith = null;
-				if(replacewith.Length > 8) replacewith = null;
+				if((General.Map.Config.MaxTextureNamelength > 0) && (replacewith.Length > General.Map.Config.MaxTextureNamelength)) replacewith = null;
 				if(replacewith == null)
 				{
 					MessageBox.Show("Invalid replace value for this search type!", "Find and Replace", MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/Source/Plugins/BuilderModes/FindReplace/FindSidedefTexture.cs
+++ b/Source/Plugins/BuilderModes/FindReplace/FindSidedefTexture.cs
@@ -91,7 +91,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			{
 				// If it cannot be interpreted, set replacewith to null (not replacing at all)
 				if(replacewith.Length < 0) replacewith = null;
-				if(replacewith.Length > 8) replacewith = null;
+				if((General.Map.Config.MaxTextureNamelength > 0) && (replacewith.Length > General.Map.Config.MaxTextureNamelength)) replacewith = null;
 				if(replacewith == null)
 				{
 					MessageBox.Show("Invalid replace value for this search type!", "Find and Replace", MessageBoxButtons.OK, MessageBoxIcon.Error);


### PR DESCRIPTION
Fixes long texture name support in Doom Builder X.

- [x] Lump.MakeLongName()
- [x] Lump.MakeNames() 
- [x] Texture Loading
- [x] Search and Replace
- [x] Thing Sprites