### PR TITLE
Added grid alignment functionality

### DIFF
--- a/Source/Core/Editing/GridSetup.cs
+++ b/Source/Core/Editing/GridSetup.cs
@@ -345,7 +345,8 @@ namespace CodeImp.DoomBuilder.Editing
 	    {
 	        if (General.Map.Map.SelectedLinedefsCount != 1)
 	        {
-	            General.ShowErrorMessage("Exactly one linedef must be selected.", MessageBoxButtons.OK);
+	            General.Interface.DisplayStatus(StatusType.Warning, "Exactly one linedef must be selected");
+	            General.Interface.MessageBeep(MessageBeepType.Warning);
 	            return;
 	        }
 	        Linedef line = General.Map.Map.SelectedLinedefs.First.Value;
@@ -360,7 +361,8 @@ namespace CodeImp.DoomBuilder.Editing
 	    {
 	        if (General.Map.Map.SelectedVerticessCount != 1)
 	        {
-	            General.ShowErrorMessage("Exactly one vertex must be selected.", MessageBoxButtons.OK);
+	            General.Interface.DisplayStatus(StatusType.Warning, "Exactly one vertex must be selected");
+	            General.Interface.MessageBeep(MessageBeepType.Warning);
 	            return;
 	        }
 	        Vertex vertex = General.Map.Map.SelectedVertices.First.Value;

--- a/Source/Core/Geometry/Line2D.cs
+++ b/Source/Core/Geometry/Line2D.cs
@@ -199,11 +199,10 @@ namespace CodeImp.DoomBuilder.Geometry
 	    {
 	        int flags1 = MapSet.GetCSFieldBits(line.v1, ref rect);
 	        int flags2 = MapSet.GetCSFieldBits(line.v2, ref rect);
-	        Line2D result = line;
 	        intersects = false;
 
-	        // Each pass will modify one coordinate of one endpoint
-	        for (int pass = 0; pass < 4; pass++)
+	        Line2D result = line;
+	        while (true)
 	        {
 	            if (flags1 == 0 && flags2 == 0)
 	            {
@@ -211,10 +210,11 @@ namespace CodeImp.DoomBuilder.Geometry
 	                intersects = true;
 	                return result;
 	            }
-
+				
 	            if ((flags1 & flags2) != 0)
 	            {
 	                // Both points are in the same outer area
+	                intersects = false;
 	                return new Line2D();
 	            }
 
@@ -222,43 +222,41 @@ namespace CodeImp.DoomBuilder.Geometry
 	            int outFlags = flags1 != 0 ? flags1 : flags2;
 	            if ((outFlags & 0x1) > 0) // Top
 	            {
-	                x = line.v1.x + (line.v2.x - line.v1.x) * (rect.Top - line.v1.y) / (line.v2.y - line.v1.y);
+	                x = result.v1.x + (result.v2.x - result.v1.x) * (rect.Top - result.v1.y) / (result.v2.y - result.v1.y);
 	                y = rect.Top;
 	            }
 	            else if ((outFlags & 0x2) > 0) // Bottom
 	            {
-	                x = line.v1.x + (line.v2.x - line.v1.x) * (rect.Bottom - line.v1.y) / (line.v2.y - line.v1.y);
+	                x = result.v1.x + (result.v2.x - result.v1.x) * (rect.Bottom - result.v1.y) / (result.v2.y - result.v1.y);
 	                y = rect.Bottom;
 	            }
 	            else if ((outFlags & 0x4) > 0) // Left
 	            {
-	                y = line.v1.y + (line.v2.y - line.v1.y) * (rect.Left - line.v1.x) / (line.v2.x - line.v1.x);
+	                y = result.v1.y + (result.v2.y - result.v1.y) * (rect.Left - result.v1.x) / (result.v2.x - result.v1.x);
 	                x = rect.Left;
 	            }
 	            else if ((outFlags & 0x8) > 0) // Right
 	            {
-	                y = line.v1.y + (line.v2.y - line.v1.y) * (rect.Right - line.v1.x) / (line.v2.x - line.v1.x);
+	                y = result.v1.y + (result.v2.y - result.v1.y) * (rect.Right - result.v1.x) / (result.v2.x - result.v1.x);
 	                x = rect.Right;
 	            } 
 	            else
 	            {
-	                intersects = false;
-	                return new Line2D();
+	                intersects = true;
+	                return result;
 	            }
 
 	            if (outFlags == flags1)
 	            {
-	                line.v1 = new Vector2D(x, y);
-	                flags1 = MapSet.GetCSFieldBits(line.v1, ref rect);
+	                result.v1 = new Vector2D(x, y);
+	                flags1 = MapSet.GetCSFieldBits(result.v1, ref rect);
 	            }
 	            else
 	            {
-	                line.v2 = new Vector2D(x, y);
-	                flags2 = MapSet.GetCSFieldBits(line.v2, ref rect);
+	                result.v2 = new Vector2D(x, y);
+	                flags2 = MapSet.GetCSFieldBits(result.v2, ref rect);
 	            }
 	        }
-
-	        return line;
 	    }
 		
 		#endregion

--- a/Source/Core/Geometry/Line2D.cs
+++ b/Source/Core/Geometry/Line2D.cs
@@ -19,8 +19,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
 using System.Text;
+using CodeImp.DoomBuilder.Map;
 
 #endregion
 
@@ -191,6 +193,73 @@ namespace CodeImp.DoomBuilder.Geometry
 			// Calculate and return intersection offset
 			return new Vector2D(v1.x + u * (v2.x - v1.x), v1.y + u * (v2.y - v1.y));
 		}
+
+	    // Cohen-Sutherland algorithm
+	    public static Line2D ClipToRectangle(Line2D line, RectangleF rect, out bool intersects)
+	    {
+	        int flags1 = MapSet.GetCSFieldBits(line.v1, ref rect);
+	        int flags2 = MapSet.GetCSFieldBits(line.v2, ref rect);
+	        Line2D result = line;
+	        intersects = false;
+
+	        // Each pass will modify one coordinate of one endpoint
+	        for (int pass = 0; pass < 4; pass++)
+	        {
+	            if (flags1 == 0 && flags2 == 0)
+	            {
+	                // Line is fully inside the box
+	                intersects = true;
+	                return result;
+	            }
+
+	            if ((flags1 & flags2) != 0)
+	            {
+	                // Both points are in the same outer area
+	                return new Line2D();
+	            }
+
+	            float x, y;
+	            int outFlags = flags1 != 0 ? flags1 : flags2;
+	            if ((outFlags & 0x1) > 0) // Top
+	            {
+	                x = line.v1.x + (line.v2.x - line.v1.x) * (rect.Top - line.v1.y) / (line.v2.y - line.v1.y);
+	                y = rect.Top;
+	            }
+	            else if ((outFlags & 0x2) > 0) // Bottom
+	            {
+	                x = line.v1.x + (line.v2.x - line.v1.x) * (rect.Bottom - line.v1.y) / (line.v2.y - line.v1.y);
+	                y = rect.Bottom;
+	            }
+	            else if ((outFlags & 0x4) > 0) // Left
+	            {
+	                y = line.v1.y + (line.v2.y - line.v1.y) * (rect.Left - line.v1.x) / (line.v2.x - line.v1.x);
+	                x = rect.Left;
+	            }
+	            else if ((outFlags & 0x8) > 0) // Right
+	            {
+	                y = line.v1.y + (line.v2.y - line.v1.y) * (rect.Right - line.v1.x) / (line.v2.x - line.v1.x);
+	                x = rect.Right;
+	            } 
+	            else
+	            {
+	                intersects = false;
+	                return new Line2D();
+	            }
+
+	            if (outFlags == flags1)
+	            {
+	                line.v1 = new Vector2D(x, y);
+	                flags1 = MapSet.GetCSFieldBits(line.v1, ref rect);
+	            }
+	            else
+	            {
+	                line.v2 = new Vector2D(x, y);
+	                flags2 = MapSet.GetCSFieldBits(line.v2, ref rect);
+	            }
+	        }
+
+	        return line;
+	    }
 		
 		#endregion
 
@@ -276,6 +345,18 @@ namespace CodeImp.DoomBuilder.Geometry
 		{
 			return Line2D.GetCoordinatesAt(v1, v2, u);
 		}
+
+	    public Line2D GetTransformed(float offsetx, float offsety, float scalex, float scaley)
+	    {
+	        return new Line2D(v1.GetTransformed(offsetx, offsety, scalex, scaley),
+	            v2.GetTransformed(offsetx, offsety, scalex, scaley));
+	    }
+
+	    public Line2D GetInvTransformed(float invoffsetx, float invoffsety, float invscalex, float invscaley)
+	    {
+	        return new Line2D(v1.GetInvTransformed(invoffsetx, invoffsety, invscalex, invscaley), 
+	            v2.GetInvTransformed(invoffsetx, invoffsety, invscalex, invscaley));
+	    }
 		
 		#endregion
 	}

--- a/Source/Core/Map/MapSet.cs
+++ b/Source/Core/Map/MapSet.cs
@@ -2057,14 +2057,19 @@ namespace CodeImp.DoomBuilder.Map
         }
 
         // This returns the cohen-sutherland field bits for a vertex in a rectangle area
-        private static int GetCSFieldBits(Vertex v, ref RectangleF area)
+        internal static int GetCSFieldBits(Vector2D v, ref RectangleF area)
         {
             int bits = 0;
-            if (v.Position.y < area.Top) bits |= 0x01;
-            if (v.Position.y > area.Bottom) bits |= 0x02;
-            if (v.Position.x < area.Left) bits |= 0x04;
-            if (v.Position.x > area.Right) bits |= 0x08;
+            if (v.y < area.Top) bits |= 0x01;
+            if (v.y > area.Bottom) bits |= 0x02;
+            if (v.x < area.Left) bits |= 0x04;
+            if (v.x > area.Right) bits |= 0x08;
             return bits;
+        }
+
+        internal static int GetCSFieldBits(Vertex v, ref RectangleF area)
+        {
+            return GetCSFieldBits(v.Position, ref area);
         }
 
         /// <summary>This filters vertices by a rectangular area.</summary>

--- a/Source/Core/Rendering/Plotter.cs
+++ b/Source/Core/Rendering/Plotter.cs
@@ -223,7 +223,7 @@ namespace CodeImp.DoomBuilder.Rendering
 
 		// This draws a line normally
 		// See: http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
-		public void DrawLineSolid(int x1, int y1, int x2, int y2, ref PixelColor c)
+		public void DrawLineSolid(int x1, int y1, int x2, int y2, ref PixelColor c, uint mask = 0xffffffff)
 		{
 			int i;
 
@@ -278,7 +278,9 @@ namespace CodeImp.DoomBuilder.Rendering
 						px += sdx;
 
 						// Draw pixel
-						pixels[py * width + px] = c;
+					    if ((mask & (1 << (i & 0x7))) != 0) {
+					        pixels[py * width + px] = c;
+					    }
 					}
 				}
 				// Else the line is more vertical than horizontal
@@ -295,7 +297,9 @@ namespace CodeImp.DoomBuilder.Rendering
 						py += sdy;
 
 						// Draw pixel
-						pixels[py * width + px] = c;
+					    if ((mask & (1 << (i & 0x7))) != 0) {
+					        pixels[py * width + px] = c;
+					    }
 					}
 				}
 			}
@@ -318,9 +322,11 @@ namespace CodeImp.DoomBuilder.Rendering
 						}
 						px += sdx;
 						
-						// Draw pixel
-						if((px >= 0) && (px < visiblewidth) && (py >= 0) && (py < visibleheight))
-							pixels[py * width + px] = c;
+						// Draw pixel						
+					    if ((mask & (1 << (i & 0x7))) != 0) {
+					        if((px >= 0) && (px < visiblewidth) && (py >= 0) && (py < visibleheight))
+					            pixels[py * width + px] = c;
+					    }
 					}
 				}
 				// Else the line is more vertical than horizontal
@@ -337,8 +343,10 @@ namespace CodeImp.DoomBuilder.Rendering
 						py += sdy;
 						
 						// Draw pixel
-						if((px >= 0) && (px < visiblewidth) && (py >= 0) && (py < visibleheight))
-							pixels[py * width + px] = c;
+					    if ((mask & (1 << (i & 0x7))) != 0) {
+					        if((px >= 0) && (px < visiblewidth) && (py >= 0) && (py < visibleheight))
+					            pixels[py * width + px] = c;
+					    }
 					}
 				}
 			}

--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -822,7 +822,7 @@ namespace CodeImp.DoomBuilder.Rendering
 				gridplotter = new Plotter((PixelColor*)lockedrect.Data.DataPointer.ToPointer(), lockedrect.Pitch / sizeof(PixelColor), backsize.Height, backsize.Width, backsize.Height);
 				gridplotter.Clear();
 
-			    bool transformed = General.Map.Grid.GridOriginX != 0 || General.Map.Grid.GridOriginY != 0 || Math.Abs(General.Map.Grid.GridRotate) > 1e-4;
+			    bool transformed = Math.Abs(General.Map.Grid.GridOriginX) > 1e-4 || Math.Abs(General.Map.Grid.GridOriginY) > 1e-4 || Math.Abs(General.Map.Grid.GridRotate) > 1e-4;
 
 			    if (transformed)
 			    {
@@ -870,15 +870,10 @@ namespace CodeImp.DoomBuilder.Rendering
 		    {
 			    float sizeinv = 1f / size;
 
-			    if (size < 1 || size > 1024)
-			    {
-				    return;
-			    }
-
 			    // Determine map coordinates for view window
-			    Vector2D ltpos = DisplayToMap(new Vector2D(0, 0));
-			    Vector2D rbpos = DisplayToMap(new Vector2D(windowsize.Width, windowsize.Height));
-			    Vector2D mapsize = rbpos - ltpos;
+			    Vector2D ltview = DisplayToMap(new Vector2D(0, 0));
+			    Vector2D rbview = DisplayToMap(new Vector2D(windowsize.Width, windowsize.Height));
+			    Vector2D mapsize = rbview - ltview;
 
 			    Vector2D ltbound = new Vector2D(General.Map.Config.LeftBoundary, General.Map.Config.TopBoundary);
 			    Vector2D rbbound = new Vector2D(General.Map.Config.RightBoundary, General.Map.Config.BottomBoundary);
@@ -887,8 +882,7 @@ namespace CodeImp.DoomBuilder.Rendering
 			    Vector2D tlb = ltbound.GetTransformed(translatex, translatey, scale, -scale);
 			    Vector2D rbb = rbbound.GetTransformed(translatex, translatey, scale, -scale);
 
-			    Vector2D xcenter = GridSetup.SnappedToGrid(0.5f * (ltpos + rbpos), size, sizeinv, angle, originx, originy);
-			    Vector2D ycenter = xcenter;
+			    Vector2D center = GridSetup.SnappedToGrid(0.5f * (ltview + rbview), size, sizeinv, angle, originx, originy);
 
 			    // Get the angle vectors for the gridlines
 			    Vector2D dx = new Vector2D((float)Math.Cos(angle), (float)Math.Sin(angle));
@@ -896,15 +890,16 @@ namespace CodeImp.DoomBuilder.Rendering
 
 			    float maxextent = Math.Max(mapsize.x, mapsize.y);
 			    RectangleF bounds = new RectangleF(tlb.x, tlb.y, rbb.x - tlb.x, rbb.y - tlb.y);
+			    bounds.Intersect(new RectangleF(0, 0, windowsize.Width, windowsize.Height));
 
 			    bool xminintersect = true, xmaxintersect = true, yminintersect = true, ymaxintersect = true;
 
 			    int num = 0;            
 			    while (xminintersect || xmaxintersect || yminintersect || ymaxintersect) {
-				    Vector2D xminstart = xcenter - num * size * dy;
-				    Vector2D xmaxstart = xcenter + num * size * dy;
-				    Vector2D yminstart = ycenter - num * size * dx;
-				    Vector2D ymaxstart = ycenter + num * size * dx;
+				    Vector2D xminstart = center - num * size * dy;
+				    Vector2D xmaxstart = center + num * size * dy;
+				    Vector2D yminstart = center - num * size * dx;
+				    Vector2D ymaxstart = center + num * size * dx;
 
 				    Line2D xminscanline = new Line2D(xminstart - dx * maxextent, xminstart + dx * maxextent);
 				    Line2D xmaxscanline = new Line2D(xmaxstart - dx * maxextent, xmaxstart + dx * maxextent);

--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -124,6 +124,9 @@ namespace CodeImp.DoomBuilder.Rendering
 		private int lastgridsize;
 		private float lastgridx;
 		private float lastgridy;
+        private float lastgridrotate;
+        private float lastgridoriginx;
+        private float lastgridoriginy;
 		private RectangleF viewport;
 		private RectangleF yviewport;
 
@@ -389,6 +392,9 @@ namespace CodeImp.DoomBuilder.Rendering
 			thingsvertices = null;
 			lastgridscale = -1f;
 			lastgridsize = 0;
+            lastgridoriginx = 0;
+            lastgridoriginy = 0;
+            lastgridrotate = 0;
 
 			// Trash font
 			if(font != null) font.Dispose();
@@ -458,6 +464,9 @@ namespace CodeImp.DoomBuilder.Rendering
 			lastgridsize = 0;
 			lastgridx = 0.0f;
 			lastgridy = 0.0f;
+		    lastgridoriginx = 0;
+		    lastgridoriginy = 0;
+		    lastgridrotate = 0;
 			UpdateTransformations();
 		}
 
@@ -803,7 +812,8 @@ namespace CodeImp.DoomBuilder.Rendering
 			
 			// Do we need to redraw grid?
 			if((lastgridsize != General.Map.Grid.GridSize) || (lastgridscale != scale) ||
-			   (lastgridx != offsetx) || (lastgridy != offsety))
+			   (lastgridx != offsetx) || (lastgridy != offsety) || (lastgridrotate != General.Map.Grid.GridRotate) || 
+			   (lastgridoriginx != General.Map.Grid.GridOriginX) || (lastgridoriginy != General.Map.Grid.GridOriginY))
 			{
 				// Lock background rendertarget memory
 				lockedrect = backtex.LockRectangle(0, LockFlags.NoSystemLock);
@@ -812,11 +822,29 @@ namespace CodeImp.DoomBuilder.Rendering
 				gridplotter = new Plotter((PixelColor*)lockedrect.Data.DataPointer.ToPointer(), lockedrect.Pitch / sizeof(PixelColor), backsize.Height, backsize.Width, backsize.Height);
 				gridplotter.Clear();
 
-				// Render normal grid
-				RenderGrid(General.Map.Grid.GridSize, General.Colors.Grid, gridplotter);
+			    bool transformed = General.Map.Grid.GridOriginX != 0 || General.Map.Grid.GridOriginY != 0 || Math.Abs(General.Map.Grid.GridRotate) > 1e-4;
 
-				// Render 64 grid
-				if(General.Map.Grid.GridSize <= 64) RenderGrid(64f, General.Colors.Grid64, gridplotter);
+			    if (transformed)
+			    {
+			        // Render normal grid
+			        RenderGridTransformed(General.Map.Grid.GridSizeF, General.Map.Grid.GridRotate,
+			            General.Map.Grid.GridOriginX, General.Map.Grid.GridOriginY, General.Colors.Grid, gridplotter);
+
+			        // Render 64 grid
+			        if(General.Map.Grid.GridSizeF <= 64)
+			        {
+			            RenderGridTransformed(64f, General.Map.Grid.GridRotate,
+			                General.Map.Grid.GridOriginX, General.Map.Grid.GridOriginY, General.Colors.Grid64, gridplotter);
+			        }
+			    } 
+			    else
+			    {
+			        // Render normal grid
+                    RenderGrid(General.Map.Grid.GridSizeF, General.Colors.Grid, gridplotter);
+
+                    // Render 64 grid
+			        if(General.Map.Grid.GridSizeF <= 64) RenderGrid(64f, General.Colors.Grid64, gridplotter);
+                }
 
 				// Done
 				backtex.UnlockRectangle(0);
@@ -825,7 +853,93 @@ namespace CodeImp.DoomBuilder.Rendering
 				lastgridsize = General.Map.Grid.GridSize;
 				lastgridx = offsetx;
 				lastgridy = offsety;
+			    lastgridoriginx = General.Map.Grid.GridOriginX;
+			    lastgridoriginy = General.Map.Grid.GridOriginY;
+			    lastgridrotate = General.Map.Grid.GridRotate;
 			}
+		}
+
+        	// This renders the grid with a transform applied
+		private void RenderGridTransformed(float size, float angle, float originx, float originy, PixelColor c, Plotter gridplotter)
+		{
+			const int mask = 0x55555555; // dotted line mask
+			Vector2D pos = new Vector2D();
+
+		    // Only render grid when not screen-filling
+		    if((size * scale) > 6f)
+		    {
+			    float sizeinv = 1f / size;
+
+			    if (size < 1 || size > 1024)
+			    {
+				    return;
+			    }
+
+			    // Determine map coordinates for view window
+			    Vector2D ltpos = DisplayToMap(new Vector2D(0, 0));
+			    Vector2D rbpos = DisplayToMap(new Vector2D(windowsize.Width, windowsize.Height));
+			    Vector2D mapsize = rbpos - ltpos;
+
+			    Vector2D ltbound = new Vector2D(General.Map.Config.LeftBoundary, General.Map.Config.TopBoundary);
+			    Vector2D rbbound = new Vector2D(General.Map.Config.RightBoundary, General.Map.Config.BottomBoundary);
+
+			    // Translate top left boundary and right bottom boundary of map to screen coords
+			    Vector2D tlb = ltbound.GetTransformed(translatex, translatey, scale, -scale);
+			    Vector2D rbb = rbbound.GetTransformed(translatex, translatey, scale, -scale);
+
+			    Vector2D xcenter = GridSetup.SnappedToGrid(0.5f * (ltpos + rbpos), size, sizeinv, angle, originx, originy);
+			    Vector2D ycenter = xcenter;
+
+			    // Get the angle vectors for the gridlines
+			    Vector2D dx = new Vector2D((float)Math.Cos(angle), (float)Math.Sin(angle));
+			    Vector2D dy = new Vector2D((float)-Math.Sin(angle), (float)Math.Cos(angle));
+
+			    float maxextent = Math.Max(mapsize.x, mapsize.y);
+			    RectangleF bounds = new RectangleF(tlb.x, tlb.y, rbb.x - tlb.x, rbb.y - tlb.y);
+
+			    bool xminintersect = true, xmaxintersect = true, yminintersect = true, ymaxintersect = true;
+
+			    int num = 0;            
+			    while (xminintersect || xmaxintersect || yminintersect || ymaxintersect) {
+				    Vector2D xminstart = xcenter - num * size * dy;
+				    Vector2D xmaxstart = xcenter + num * size * dy;
+				    Vector2D yminstart = ycenter - num * size * dx;
+				    Vector2D ymaxstart = ycenter + num * size * dx;
+
+				    Line2D xminscanline = new Line2D(xminstart - dx * maxextent, xminstart + dx * maxextent);
+				    Line2D xmaxscanline = new Line2D(xmaxstart - dx * maxextent, xmaxstart + dx * maxextent);
+				    Line2D yminscanline = new Line2D(yminstart - dy * maxextent, yminstart + dy * maxextent);
+				    Line2D ymaxscanline = new Line2D(ymaxstart - dy * maxextent, ymaxstart + dy * maxextent);
+
+				    Line2D xminplotline = xminscanline.GetTransformed(translatex, translatey, scale, -scale);
+				    Line2D xmaxplotline = xmaxscanline.GetTransformed(translatex, translatey, scale, -scale);
+				    Line2D yminplotline = yminscanline.GetTransformed(translatex, translatey, scale, -scale);
+				    Line2D ymaxplotline = ymaxscanline.GetTransformed(translatex, translatey, scale, -scale);
+				    xminplotline = Line2D.ClipToRectangle(xminplotline, bounds, out xminintersect);
+				    xmaxplotline = Line2D.ClipToRectangle(xmaxplotline, bounds, out xmaxintersect);
+				    yminplotline = Line2D.ClipToRectangle(yminplotline, bounds, out yminintersect);
+				    ymaxplotline = Line2D.ClipToRectangle(ymaxplotline, bounds, out ymaxintersect);
+
+				    if (xminintersect)
+				    {
+					    gridplotter.DrawLineSolid((int)xminplotline.v1.x, (int)xminplotline.v1.y, (int)xminplotline.v2.x, (int)xminplotline.v2.y, ref c, mask);
+				    }
+				    if (xmaxintersect)
+				    {
+					    gridplotter.DrawLineSolid((int)xmaxplotline.v1.x, (int)xmaxplotline.v1.y, (int)xmaxplotline.v2.x, (int)xmaxplotline.v2.y, ref c, mask);
+				    }
+				    if (yminintersect)
+				    {
+					    gridplotter.DrawLineSolid((int)yminplotline.v1.x, (int)yminplotline.v1.y, (int)yminplotline.v2.x, (int)yminplotline.v2.y, ref c, mask);
+				    }
+				    if (ymaxintersect)
+				    {
+					    gridplotter.DrawLineSolid((int)ymaxplotline.v1.x, (int)ymaxplotline.v1.y, (int)ymaxplotline.v2.x, (int)ymaxplotline.v2.y, ref c, mask);
+				    }
+
+				    num++;
+			    }
+            }
 		}
 		
 		// This renders the grid

--- a/Source/Core/Resources/Actions.cfg
+++ b/Source/Core/Resources/Actions.cfg
@@ -329,6 +329,36 @@ decrementtag
 	allowscroll = true;
 }
 
+aligngridtolinedef
+{
+	title = "Align Grid to Selected Linedef";
+	category = "classic";
+	description = "Realigns the grid so that the selected linedef is on a grid line.";
+	allowkeys = true;
+	allowmouse = false;
+	allowscroll = false;
+}
+
+setgridorigintovertex
+{
+	title = "Set Grid Origin to Selected Vertex";
+	category = "classic";
+	description = "Repositions the grid so that the selected vertex is at the origin.";
+	allowkeys = true;
+	allowmouse = false;
+	allowscroll = false;
+}
+
+resetgrid
+{
+	title = "Reset Grid Transform";
+	category = "classic";
+	description = "Resets the grid to the default coordinate system.";
+	allowkeys = true;
+	allowmouse = false;
+	allowscroll = false;
+}
+
 griddec		// Note, these were incorrectly swapped before, hence the wrong action name
 {
 	title = "Grid Increase";

--- a/Source/Core/Windows/MainForm.Designer.cs
+++ b/Source/Core/Windows/MainForm.Designer.cs
@@ -179,6 +179,9 @@ namespace CodeImp.DoomBuilder.Windows
             this.dockersspace = new System.Windows.Forms.Panel();
             this.dockerspanel = new CodeImp.DoomBuilder.Controls.DockersControl();
             this.dockerscollapser = new System.Windows.Forms.Timer(this.components);
+            this.itemaligngridtolinedef = new System.Windows.Forms.ToolStripMenuItem();
+            this.itemsetgridorigintovertex = new System.Windows.Forms.ToolStripMenuItem();
+            this.itemresetgrid = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
@@ -409,6 +412,9 @@ namespace CodeImp.DoomBuilder.Windows
             this.seperatoreditgeometry,
             this.itemgridinc,
             this.itemgriddec,
+            this.itemaligngridtolinedef,
+            this.itemsetgridorigintovertex,
+            this.itemresetgrid,
             this.itemgridsetup,
             this.seperatoreditgrid,
             this.itemmapoptions,
@@ -520,6 +526,31 @@ namespace CodeImp.DoomBuilder.Windows
             this.itemgriddec.Tag = "builder_gridinc";
             this.itemgriddec.Text = "&Decrease Grid";
             this.itemgriddec.Click += new System.EventHandler(this.InvokeTaggedAction);
+            // 
+            // itemaligngridtolinedef
+            //
+            this.itemaligngridtolinedef.Name = "itemaligngridtolinedef";
+            this.itemaligngridtolinedef.Size = new System.Drawing.Size(215, 22);
+            this.itemaligngridtolinedef.Tag = "builder_aligngridtolinedef";
+            this.itemaligngridtolinedef.Text = "Align Grid To Selected Linedef";
+            this.itemaligngridtolinedef.Click += new System.EventHandler(this.InvokeTaggedAction);
+            // 
+            // itemsetgridorigintovertex
+            //
+            this.itemsetgridorigintovertex.Name = "itemsetgridorigintovertex";
+            this.itemsetgridorigintovertex.Size = new System.Drawing.Size(215, 22);
+            this.itemsetgridorigintovertex.Tag = "builder_setgridorigintovertex";
+            this.itemsetgridorigintovertex.Text = "Set Grid Origin To Selected Vertex";
+            this.itemsetgridorigintovertex.Click += new System.EventHandler(this.InvokeTaggedAction);
+
+            // 
+            // itemresetgrid
+            //
+            this.itemresetgrid.Name = "itemresetgrid";
+            this.itemresetgrid.Size = new System.Drawing.Size(215, 22);
+            this.itemresetgrid.Tag = "builder_resetgrid";
+            this.itemresetgrid.Text = "Reset Grid Transform";
+            this.itemresetgrid.Click += new System.EventHandler(this.InvokeTaggedAction);
             // 
             // itemgridsetup
             // 
@@ -1752,6 +1783,9 @@ namespace CodeImp.DoomBuilder.Windows
         private System.Windows.Forms.ToolStripSeparator seperatoreditgeometry;
         private System.Windows.Forms.ToolStripMenuItem itemgridinc;
         private System.Windows.Forms.ToolStripMenuItem itemgriddec;
+        private System.Windows.Forms.ToolStripMenuItem itemaligngridtolinedef;
+        private System.Windows.Forms.ToolStripMenuItem itemsetgridorigintovertex;
+        private System.Windows.Forms.ToolStripMenuItem itemresetgrid;
         private System.Windows.Forms.ToolStripMenuItem itemgridsetup;
         private System.Windows.Forms.Label modename;
         private System.Windows.Forms.Timer statusflasher;

--- a/Source/Plugins/BuilderModes/ClassicModes/DragGeometryMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/DragGeometryMode.cs
@@ -206,7 +206,10 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						if(snaptogrid)
 						{
 							// Get grid intersection coordinates
-							List<Vector2D> coords = nl.GetGridIntersections();
+							List<Vector2D> coords = nl.GetGridIntersections(new Vector2D(0.0f, 0.0f),
+							    General.Map.Grid.GridRotate, General.Map.Grid.GridOriginX, General.Map.Grid.GridOriginY);
+
+
 
 							// Find nearest grid intersection
 							float found_distance = float.MaxValue;

--- a/Source/Plugins/BuilderModes/ClassicModes/DrawGeometryMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/DrawGeometryMode.cs
@@ -278,7 +278,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if(snaptogrid)
 					{
 						// Get grid intersection coordinates
-						List<Vector2D> coords = nl.GetGridIntersections();
+					    List<Vector2D> coords = nl.GetGridIntersections(new Vector2D(0.0f, 0.0f),
+					        General.Map.Grid.GridRotate, General.Map.Grid.GridOriginX, General.Map.Grid.GridOriginY);
 
 						// Find nearest grid intersection
 						bool found = false;


### PR DESCRIPTION
This pull request adds some new functionality to allow the grid to be rotated and translated. In this first iteration, there are three new functions added to the Edit menu:

- Align Grid to Selected Linedef: This will rotate the grid so that one of the axes is parallel to the selected linedef. It will also modify the grid's origin to the starting vertex of the linedef, ensuring that the selected linedef lies on a grid line.
- Set Grid Origin to Selected Vertex: This will change the grid's origin to the selected vertex, ensuring that the selected vertex lies exactly on the intersection of two grid lines.
- Reset Grid: This resets the grid back to Doom's coordinate space.

I didn't create any default keybinds but I manually set them up as:

- Align to Sidedef = Keypad +
- Set Origin to Vertex = Keypad .
- Reset = Keypad /

which works well for me.


[Preview](https://i.imgur.com/JSrS6bJ.mp4)

I created this earlier today as a patch for GZDoomBuilderBugfix ([Pull Request](https://github.com/jewalky/GZDoom-Builder-Bugfix/pull/252)) but was asked if I could also implement it for DoomBuilderX. Luckily the code translated almost directly.