### PR TITLE
Fix Null Ref Exception when removing Sidedef in Visual Mode

### DIFF
--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -376,7 +376,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				{
 					VisualGeometry pickedgeo = (target.picked as VisualGeometry);
 
-					if(pickedgeo.Sidedef != null)
+					if(pickedgeo.Sidedef != null && pickedgeo.Sidedef.Line != null)
 						General.Interface.ShowLinedefInfo(pickedgeo.Sidedef.Line);
 					else if(pickedgeo.Sidedef == null)
 						General.Interface.ShowSectorInfo(pickedgeo.Sector.Sector);


### PR DESCRIPTION
This fixes the Null Reference Exception that would occur when removing a Sidedef while in Visual Mode (issue logged on GitHub as Issue #17 - Null reference exception when removing Sidedef in Visual mode)

Enter Visual Mode (click button in toolbar, or press 'W' key)
Focus on a wall
Right-click to open the 'Edit Linedefs' window
Select the 'Sidedefs' tab
Uncheck the 'Front Side' and/or 'Back Side' checkbox
Click the 'OK' button
The exception will occur