### PR TITLE
Fix wrong Teleport_Other enum (ZDoom special)

### DIFF
--- a/data/Configurations/Includes/ZDoom_linedefs.cfg
+++ b/data/Configurations/Includes/ZDoom_linedefs.cfg
@@ -1411,7 +1411,7 @@ hexen
 			{
 				title = "Fog";
 				type = 11;
-				enum = "yesno";
+				enum = "noyes";
 			}
 		}
 		


### PR DESCRIPTION
It should be the other way around, i.e. `noyes`, not `yesno`.